### PR TITLE
Update path to model file

### DIFF
--- a/03-PartRightClicking/GameData/ThunderAerospace/Examples/PartRightClick/part.cfg
+++ b/03-PartRightClicking/GameData/ThunderAerospace/Examples/PartRightClick/part.cfg
@@ -12,7 +12,7 @@ author = TaranisElsu
 
 MODEL
 {
-	model = Squad/Parts/Utility/sensorAccelerometer/model
+	model = Squad/Parts/Science/sensorAccelerometer/model
 	position = 0.0, 0.0, 0.0
 	scale = 1.0, 1.0, 1.0
 	rotation = 0, 0, 0


### PR DESCRIPTION
This probably changed some time in the past decade, but the path to the accelerometer model in the cfg file is currently wrong. The model can be found in Parts/Science instead.